### PR TITLE
Fixing URL to be swift.com instead of swift.org

### DIFF
--- a/docs/partner_editable/faq_troubleshooting.adoc
+++ b/docs/partner_editable/faq_troubleshooting.adoc
@@ -31,4 +31,4 @@ or
 
 == Troubleshooting
 
-For any issues or questions with installing SWIFT components, see the https://swift.org/documentation/[SWIFT documentation]. All SWIFT software is available from the https://swift.org/download/#releases[SWIFT download center].
+For any issues or questions with installing SWIFT components, see the https://www.swift.com/myswift[SWIFT documentation]. All SWIFT software is available from the https://www.swift.com/myswift/ordering/order-products-services[SWIFT download center].


### PR DESCRIPTION
Fixing the links which pointed to swift.org to be: https://www.swift.com/myswift and https://www.swift.com/myswift/ordering/order-products-services

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
